### PR TITLE
Add _ exception to no-unused-vars rule

### DIFF
--- a/configs/base.js
+++ b/configs/base.js
@@ -58,5 +58,15 @@ module.exports = {
       },
     ],
     'simple-import-sort/exports': 'error',
+
+    // Vars
+    "unused-imports/no-unused-vars": [
+      "error",
+      {
+        "vars": "all",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+      },
+    ],
   },
 };

--- a/configs/base.js
+++ b/configs/base.js
@@ -60,7 +60,7 @@ module.exports = {
     'simple-import-sort/exports': 'error',
 
     // Vars
-    "unused-imports/no-unused-vars": [
+    "@typescript-eslint/no-unused-vars": [
       "error",
       {
         "vars": "all",


### PR DESCRIPTION
I've made this change through GIthub UI, please test it before merging.

The current config gives me an error if my function argument starts with _:

```
function handleClick(_: MouseEvent<HTMLButtonElement>) {}
```

I need the argument to be there so that the TS type for my func is correct.